### PR TITLE
Improve assertions

### DIFF
--- a/tests/HalClientTest.php
+++ b/tests/HalClientTest.php
@@ -43,10 +43,10 @@ class HalClientTest extends TestCase
         $this->assertFalse($resource->hasProperty('foobar'));
         $this->assertNull($resource->getProperty('foobar'));
         $this->assertEquals(33, $resource->getProperty('age'));
-        $this->assertEquals(false, $resource->getProperty('expired'));
+        $this->assertFalse($resource->getProperty('expired'));
         $this->assertEquals(123456, $resource->getProperty('id'));
         $this->assertEquals('Example Resource', $resource->getProperty('name'));
-        $this->assertEquals(true, $resource->getProperty('optional'));
+        $this->assertTrue($resource->getProperty('optional'));
 
         $this->assertCount(0, $resource->getResources());
     }


### PR DESCRIPTION
# Changed log
- Using the `assertTrue` to assert expected value is `true`.
- Using the `assertFalse` to assert expected value is `false`.